### PR TITLE
Add tap-yaml dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "ink": "^3.2.0",
         "ms": "^2.1.2",
         "tap-parser": "^11.0.0",
+        "tap-yaml": "^1.0.0",
         "unicode-length": "^2.0.2"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "ink": "^3.2.0",
     "ms": "^2.1.2",
     "tap-parser": "^11.0.0",
+    "tap-yaml": "^1.0.0",
     "unicode-length": "^2.0.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
`treport` relies on `tap` to pull in `tap-yaml`, but doesn't declare that dependency itself. That breaks in Yarn v2+.